### PR TITLE
Use new version of Conan and update run script to match

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM wsbu/toolchain-native:v0.3.2
+FROM wsbu/toolchain-native:v0.3.4
 
 ENV TOOLCHAIN_ARCHIVE_NAME="xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz"
 
 COPY conan/esp32_profile "${HOME}/.conan/profiles/esp32"
 
-RUN apt-get update && apt-get install --yes --no-install-recommends \
+RUN apt-get update && sudo apt-get install --yes --no-install-recommends \
     libncurses-dev \
     flex \
     bison \
     gperf \
-  && pip --no-cache-dir install \
+    python-pip
+
+RUN pip2 --no-cache-dir install \
     pyserial>=3.0 \
-    future>=0.15.2 \
-    cryptography>=2.1.4 \
     pyparsing>=2.0.3 \
   && wget --quiet "https://dl.espressif.com/dl/${TOOLCHAIN_ARCHIVE_NAME}" -O - | tar xz --strip 1 -C /usr/local \
   && ln -sf "${HOME}/.conan/profiles/esp32" "${HOME}/.conan/profiles/default" \

--- a/docker-esp32
+++ b/docker-esp32
@@ -7,8 +7,19 @@ dir="$(pwd)"
 set -e
 
 mkdir --parents ~/.conan/data
-touch ~/.conan/.conan.db
-touch ~/.conan/registry.json
+
+if [[ ! -e "${HOME}/.conan/.conan.db" ]] ; then
+    echo "Conan database (~/.conan/.conan.db) does not exist. Please initialize Conan for your host system first."
+    exit 1
+fi
+if [[ ! -e "${HOME}/.conan/remotes.json" ]] ; then
+    if [[ -e "${HOME}/.conan/registry.json" ]] ; then
+        echo "This version of the Docker image contains a different version of Conan than your most recently used version. Please use your host-installed version of Conan to migrate and then try again."
+    else
+        echo "Conan database (~/.conan/remotes) does not exist. Please initialize Conan for your host system first."
+    fi
+    exit 1
+fi
 
 for device in $(ls /dev/ttyUSB*) ; do device_args="${device_args} -v ${device}:${device}" ; done
 
@@ -20,10 +31,10 @@ docker run -it --rm \
     -v "$HOME/.ssh/id_rsa:/home/captain/.ssh/id_rsa" \
     -v "$HOME/.ssh/known_hosts:/home/captain/.ssh/known_hosts" \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
-    -v "$HOME/.conan/registry.json:/home/captain/.conan/registry.json" \
+    -v "${HOME}/.conan/remotes.json:/home/captain/.conan/remotes.json" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
     ${device_args} \
     --privileged \
     -v "${dir}:${dir}" \
     -w "${dir}" \
-    wsbu/toolchain-esp32:v0.0.4 "$@"
+    wsbu/toolchain-esp32:v0.0.5 "$@"


### PR DESCRIPTION
Like the others, I'm just getting all of our Docker images synchronized to use the same (new) version of Conan.

I don't have an ESP32 board at my house, so I've shipped the image over to Rick so he can test it for me. I've confirmed that it compiles the sled fw still, but can not confirm that it can program a board.