### PR TITLE
[MAN-1679] Update base image for new conan; provides gperf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wsbu/toolchain-native:v0.3.5
+FROM wsbu/toolchain-native:v0.3.6
 
 ENV TOOLCHAIN_ARCHIVE_NAME="xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz"
 
@@ -8,7 +8,6 @@ RUN apt-get update && sudo apt-get install --yes --no-install-recommends \
     libncurses-dev \
     flex \
     bison \
-    gperf \
     python-pip
 
 RUN pip2 --no-cache-dir install \

--- a/docker-esp32
+++ b/docker-esp32
@@ -37,4 +37,4 @@ docker run -it --rm \
     --privileged \
     -v "${dir}:${dir}" \
     -w "${dir}" \
-    wsbu/toolchain-esp32:v0.0.6 "$@"
+    wsbu/toolchain-esp32:v0.0.7 "$@"


### PR DESCRIPTION
Updating base image to get new Conan. Don't need gperf anymore because the new base image also provides that.